### PR TITLE
Change setup to be used as preset

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,1 @@
 export { default as bccForbundetTheme } from "./tailwind/bccForbundetTheme";
-export { fontFamily } from "./tailwind/fontFamily";
-export { colors } from "./tailwind/colors";
-export { backgroundColor } from "./tailwind/backgroundColor";
-export { borderColor } from "./tailwind/borderColor";
-export { outlineColor } from "./tailwind/outlineColor";
-export { textColor } from "./tailwind/textColor";

--- a/src/tailwind/bccForbundetTheme.ts
+++ b/src/tailwind/bccForbundetTheme.ts
@@ -9,7 +9,6 @@ import { Config } from "tailwindcss";
 
 const bccForbundetTheme: Partial<Config> = {
   theme: {
-    extend: {
       fontFamily,
       colors,
       textColor,
@@ -18,7 +17,6 @@ const bccForbundetTheme: Partial<Config> = {
       outlineColor,
       ringColor,
     },
-  },
 };
 
-export default bccForbundetTheme.theme;
+export default bccForbundetTheme;


### PR DESCRIPTION
Utilize Tailwind's [preset](https://tailwindcss.com/docs/presets) feature so it is easier to override styles in a local config.